### PR TITLE
Use "#!/bin/bash"; script is not POSIX compliant

### DIFF
--- a/build-icons.sh
+++ b/build-icons.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 ICON_THEME_NAME="${ICON_THEME_NAME:-ClassicOS2000}"
 VERBOSE="${VERBOSE:-FALSE}"


### PR DESCRIPTION
Systems with strict POSIX-compliant shells linked to /bin/sh (like Dash) cannot run this script due to the use of Bash arrays (ICON_SIZES and ICON_CATEGORIES)